### PR TITLE
fix: Set Emulsify and Emulsify Tools to stable version hosted on drup…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     "require": {
         "drupal/components": "^3.0@beta",
         "drupal/emulsify": "^5.0",
-        "emulsify-ds/emulsify_tools": "^1.0"
+        "drupal/emulsify_tools": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,16 @@
         {
             "name": "Laura Johnson",
             "role": "Maintainer"
+        },
+        {
+            "name": "Callin Mullaney",
+            "role": "Maintainer"
         }
     ],
     "minimum-stability": "dev",
     "require": {
         "drupal/components": "^3.0@beta",
-        "emulsify-ds/emulsify-drupal": "dev-main",
-        "emulsify-ds/emulsify_tools": "dev-main"
+        "drupal/emulsify": "^5.0",
+        "emulsify-ds/emulsify_tools": "^1.0"
     }
 }


### PR DESCRIPTION
**This PR does the following:**
- Updates Emulsify to the latest 5.x version hosted on Drupal.org
- Updates the Emulsify Tools dependency to the 1.x stable release.
- Adds me as a Maintainer of the recipe :) 

### Functional Testing:
- [ ] Verify the recipe now pulls from Drupal.org when installing Sous

